### PR TITLE
GPU inference (CUDA)

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -2,6 +2,9 @@
 python_version = 3.13
 strict = True
 
+[mypy-ctranslate2]
+ignore_missing_imports = True
+
 [mypy-faster_whisper]
 ignore_missing_imports = True
 

--- a/src/voxy/__main__.py
+++ b/src/voxy/__main__.py
@@ -42,7 +42,7 @@ def main() -> None:
     config = ConfigLoader().load()
     App(
         AudioRecorder(),
-        Transcriber(model_size=config.model.size),
+        Transcriber(model_size=config.model.size, device=config.model.device),
         TextInserter(config.insertion.method),
         PostProcessor(config.post_processing),
         OverlayUI(config.ui),

--- a/src/voxy/config.py
+++ b/src/voxy/config.py
@@ -15,6 +15,7 @@ _VALID_MODEL_SIZES: frozenset[str] = frozenset(
     {"tiny", "tiny.en", "base", "base.en", "small", "small.en",
      "medium", "medium.en", "large-v1", "large-v2", "large-v3"}
 )
+_VALID_DEVICE_OPTIONS: frozenset[str] = frozenset({"auto", "cpu", "cuda"})
 _VALID_INSERTION_METHODS: frozenset[str] = frozenset({"auto", "x11", "wayland"})
 _VALID_LOG_LEVELS: frozenset[str] = frozenset({"debug", "info", "warning", "error"})
 _VALID_OVERLAY_CORNERS: frozenset[str] = frozenset(
@@ -81,6 +82,7 @@ class ModelConfig:
     size: str = "small"
     language: str = "auto"
     fallback_language: str = "en"
+    device: str = "auto"
 
 
 @dataclass(frozen=True)
@@ -203,6 +205,10 @@ language = "auto"
 # Fallback language when auto-detection confidence is low.
 fallback_language = "en"
 
+# Inference device. Options: auto, cpu, cuda
+# "auto" uses GPU when available and falls back to CPU silently.
+device = "auto"
+
 [insertion]
 # How to insert text. Options: auto, x11, wayland
 method = "auto"
@@ -250,6 +256,7 @@ def _parse_model(t: dict[str, Any]) -> ModelConfig:
         size=_as_one_of(t.get("size", ModelConfig.size), _VALID_MODEL_SIZES, "[model] size"),
         language=_as_nonempty_str(t.get("language", ModelConfig.language), "[model] language"),
         fallback_language=_as_nonempty_str(t.get("fallback_language", ModelConfig.fallback_language), "[model] fallback_language"),
+        device=_as_one_of(t.get("device", ModelConfig.device), _VALID_DEVICE_OPTIONS, "[model] device"),
     )
 
 

--- a/src/voxy/transcriber.py
+++ b/src/voxy/transcriber.py
@@ -2,14 +2,49 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
+import ctranslate2
 import numpy as np
 import numpy.typing as npt
 from faster_whisper import WhisperModel
 
 MODEL_CACHE_DIR: Path = Path.home() / ".cache" / "voxy" / "models"
 DEFAULT_MODEL_SIZE: str = "small"
+DEFAULT_DEVICE: str = "auto"
+
+_log = logging.getLogger(__name__)
+
+_COMPUTE_TYPE_PRIORITY: list[str] = ["int8_float16", "float16", "float32"]
+
+
+def _resolve_device_and_compute(device: str) -> tuple[str, str]:
+    """Return (ct2_device, compute_type) given a user device setting."""
+    if device == "cpu":
+        return "cpu", "int8"
+
+    cuda_count = ctranslate2.get_cuda_device_count()
+
+    if device == "cuda":
+        if cuda_count == 0:
+            _log.warning(
+                "device='cuda' requested but no CUDA device found; falling back to CPU"
+            )
+            return "cpu", "int8"
+
+    elif device == "auto":
+        if cuda_count == 0:
+            return "cpu", "int8"
+
+    supported = ctranslate2.get_supported_compute_types("cuda")
+    for ct in _COMPUTE_TYPE_PRIORITY:
+        if ct in supported:
+            _log.info("voxy: device=cuda compute_type=%s", ct)
+            return "cuda", ct
+
+    _log.info("voxy: device=cuda compute_type=float32 (fallback)")
+    return "cuda", "float32"
 
 
 class Transcriber:
@@ -26,18 +61,27 @@ class Transcriber:
 
     _model: WhisperModel | None
     _model_size: str
+    _ct2_device: str
+    _compute_type: str
 
-    def __init__(self, model_size: str = DEFAULT_MODEL_SIZE) -> None:
+    def __init__(
+        self,
+        model_size: str = DEFAULT_MODEL_SIZE,
+        device: str = DEFAULT_DEVICE,
+    ) -> None:
         self._model_size = model_size
+        self._ct2_device, self._compute_type = _resolve_device_and_compute(device)
         self._model = None
 
     def _get_model(self) -> WhisperModel:
         if self._model is None:
             MODEL_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+            _log.info("voxy: loading model size=%s device=%s compute_type=%s",
+                      self._model_size, self._ct2_device, self._compute_type)
             self._model = WhisperModel(
                 self._model_size,
-                device="cpu",
-                compute_type="int8",
+                device=self._ct2_device,
+                compute_type=self._compute_type,
                 download_root=str(MODEL_CACHE_DIR),
             )
         return self._model

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -136,6 +136,7 @@ def test_env_var_missing_file_returns_defaults(tmp_path: Path, monkeypatch: pyte
 
 @pytest.mark.parametrize(("toml", "fragment"), [
     ('[model]\nsize = "giant"', r"\[model\] size"),
+    ('[model]\ndevice = "rocm"', r"\[model\] device"),
     ('[insertion]\nmethod = "clipboard"', r"\[insertion\] method"),
     ('[logging]\nlevel = "verbose"', r"\[logging\] level"),
     ('[ui]\noverlay_corner = "center"', r"\[ui\] overlay_corner"),
@@ -145,4 +146,26 @@ def test_env_var_missing_file_returns_defaults(tmp_path: Path, monkeypatch: pyte
 def test_invalid_value_raises(tmp_path: Path, toml: str, fragment: str) -> None:
     path = _write(tmp_path, toml)
     with pytest.raises(ConfigError, match=fragment):
+        ConfigLoader(path).load()
+
+
+# ---------------------------------------------------------------------------
+# ModelConfig.device field
+# ---------------------------------------------------------------------------
+
+def test_model_config_device_default(tmp_path: Path) -> None:
+    cfg = ConfigLoader(tmp_path / "absent.toml").load()
+    assert cfg.model.device == "auto"
+
+
+def test_model_config_device_valid_values(tmp_path: Path) -> None:
+    for device in ("auto", "cpu", "cuda"):
+        path = _write(tmp_path, f'[model]\ndevice = "{device}"\n')
+        cfg = ConfigLoader(path).load()
+        assert cfg.model.device == device
+
+
+def test_model_config_device_invalid(tmp_path: Path) -> None:
+    path = _write(tmp_path, '[model]\ndevice = "rocm"\n')
+    with pytest.raises(ConfigError, match=r"\[model\] device"):
         ConfigLoader(path).load()

--- a/tests/test_transcriber.py
+++ b/tests/test_transcriber.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import logging
 import wave
 from pathlib import Path
 
+import ctranslate2
 import numpy as np
 import numpy.typing as npt
 import pytest
@@ -12,6 +14,8 @@ import pytest
 from voxy.transcriber import Transcriber
 
 FIXTURES = Path(__file__).parent / "fixtures"
+
+_CUDA_AVAILABLE = ctranslate2.get_cuda_device_count() > 0
 
 
 def load_wav(path: Path) -> npt.NDArray[np.float32]:
@@ -59,3 +63,58 @@ def test_transcribe_empty_audio(transcriber: Transcriber) -> None:
     empty: npt.NDArray[np.float32] = np.zeros(0, dtype=np.float32)
     result = transcriber.transcribe(empty)
     assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# Device selection — CPU paths (run everywhere)
+# ---------------------------------------------------------------------------
+
+def test_cpu_explicit_transcribes() -> None:
+    t = Transcriber(device="cpu")
+    audio = load_wav(FIXTURES / "en_hello.wav")
+    result = t.transcribe(audio)
+    assert isinstance(result, str)
+    assert "hello" in result.lower()
+
+
+def test_auto_falls_back_to_cpu_silently(caplog: pytest.LogCaptureFixture) -> None:
+    if _CUDA_AVAILABLE:
+        pytest.skip("CUDA present — auto will use GPU, not CPU fallback")
+    with caplog.at_level(logging.DEBUG, logger="voxy.transcriber"):
+        t = Transcriber(device="auto")
+    warning_msgs = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert not warning_msgs, "auto should be silent on CPU-only machine"
+    audio = load_wav(FIXTURES / "en_hello.wav")
+    assert isinstance(t.transcribe(audio), str)
+
+
+def test_cuda_explicit_falls_back_with_warning(caplog: pytest.LogCaptureFixture) -> None:
+    if _CUDA_AVAILABLE:
+        pytest.skip("CUDA present — no fallback occurs")
+    with caplog.at_level(logging.WARNING, logger="voxy.transcriber"):
+        t = Transcriber(device="cuda")
+    assert any("warning" in r.message.lower() or r.levelno >= logging.WARNING for r in caplog.records)
+    audio = load_wav(FIXTURES / "en_hello.wav")
+    assert isinstance(t.transcribe(audio), str)
+
+
+# ---------------------------------------------------------------------------
+# Device selection — GPU paths (auto-skip when no CUDA)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not _CUDA_AVAILABLE, reason="No CUDA device present")
+def test_cuda_explicit_transcribes_gpu() -> None:
+    t = Transcriber(device="cuda")
+    audio = load_wav(FIXTURES / "en_hello.wav")
+    result = t.transcribe(audio)
+    assert isinstance(result, str)
+    assert len(result) > 0
+
+
+@pytest.mark.skipif(not _CUDA_AVAILABLE, reason="No CUDA device present")
+def test_auto_uses_cuda_gpu() -> None:
+    t = Transcriber(device="auto")
+    audio = load_wav(FIXTURES / "en_hello.wav")
+    result = t.transcribe(audio)
+    assert isinstance(result, str)
+    assert len(result) > 0


### PR DESCRIPTION
Closes #27

## Summary

- `ModelConfig` gains a `device` field (`"auto"` / `"cpu"` / `"cuda"`, default `"auto"`)
- `Transcriber` resolves device and compute type eagerly at init via `ctranslate2`:
  - `"auto"`: uses GPU when present, silently falls back to CPU
  - `"cuda"`: uses GPU, logs a warning and falls back to CPU if unavailable
  - `"cpu"`: always CPU + int8
  - Compute type priority on CUDA: `int8_float16` → `float16` → `float32`
- Selected device and compute type logged at startup
- GPU tests auto-skip when `ctranslate2.get_cuda_device_count() == 0`
- `.#cuda` devShell already present (commit f2aadfc); default shell unchanged

🤖 Generated with [Claude Code](https://claude.ai/claude-code)