### PR TITLE
GPU auto-detection and compute type selection in Transcriber

### DIFF
--- a/src/voxy/transcriber.py
+++ b/src/voxy/transcriber.py
@@ -22,6 +22,7 @@ _COMPUTE_TYPE_PRIORITY: list[str] = ["int8_float16", "float16", "float32"]
 def _resolve_device_and_compute(device: str) -> tuple[str, str]:
     """Return (ct2_device, compute_type) given a user device setting."""
     if device == "cpu":
+        _log.info("voxy: device=cpu compute_type=int8")
         return "cpu", "int8"
 
     cuda_count = ctranslate2.get_cuda_device_count()
@@ -31,10 +32,12 @@ def _resolve_device_and_compute(device: str) -> tuple[str, str]:
             _log.warning(
                 "device='cuda' requested but no CUDA device found; falling back to CPU"
             )
+            _log.info("voxy: device=cpu compute_type=int8")
             return "cpu", "int8"
 
     elif device == "auto":
         if cuda_count == 0:
+            _log.info("voxy: device=cpu compute_type=int8")
             return "cpu", "int8"
 
     supported = ctranslate2.get_supported_compute_types("cuda")

--- a/tests/test_transcriber.py
+++ b/tests/test_transcriber.py
@@ -77,6 +77,15 @@ def test_cpu_explicit_transcribes() -> None:
     assert "hello" in result.lower()
 
 
+def test_device_and_compute_logged_at_init(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.INFO, logger="voxy.transcriber"):
+        Transcriber(device="cpu")
+    info_msgs = [r for r in caplog.records if r.levelno == logging.INFO]
+    assert any("cpu" in r.message and "int8" in r.message for r in info_msgs), (
+        "Expected info log with device=cpu and compute_type=int8 at init"
+    )
+
+
 def test_auto_falls_back_to_cpu_silently(caplog: pytest.LogCaptureFixture) -> None:
     if _CUDA_AVAILABLE:
         pytest.skip("CUDA present — auto will use GPU, not CPU fallback")


### PR DESCRIPTION
Closes #30

Completes the GPU auto-detection and compute type resolution in `Transcriber`:

- `_resolve_device_and_compute` selects compute type via `ctranslate2.get_supported_compute_types("cuda")` with priority `int8_float16` → `float16` → `float32`
- All three device modes handled: `cpu`, `cuda`, `auto` with correct fallback and warning behaviour
- **Adds info-level logging for CPU paths** at init so device/compute_type is always visible at startup regardless of hardware (GPU paths already logged)
- GPU integration tests auto-skip via `@pytest.mark.skipif(not _CUDA_AVAILABLE, ...)` — no CLI flags needed
- `mypy --strict` passes; 7 tests pass, 2 GPU tests auto-skip on this machine

Core device resolution logic was established in #31; this PR closes the tracking issue and adds the missing startup log for CPU paths.