### PR TITLE
fix: CUDA lib probing, Xlib noise, evdev log spam

### DIFF
--- a/src/voxy/hotkey.py
+++ b/src/voxy/hotkey.py
@@ -179,7 +179,7 @@ class HotkeyListener:
                             pressed = False
                             self._on_release()
             except OSError as exc:
-                _log.warning("evdev device lost (%s); hotkey listener falling back to pynput", exc)
+                _log.debug("evdev device lost (%s); hotkey listener falling back to pynput", exc)
             finally:
                 dev.close()
 

--- a/src/voxy/hotkey.py
+++ b/src/voxy/hotkey.py
@@ -3,14 +3,35 @@
 from __future__ import annotations
 
 import grp
+import io
 import logging
 import os
+import sys
 import threading
 from collections.abc import Callable
 
 import evdev
 import evdev.ecodes as ecodes
-from pynput import keyboard as kb
+
+
+def _import_pynput():  # type: ignore[return]
+    # On Wayland, pynput falls back to its X11 backend but xauth is empty/missing,
+    # causing a noisy print(). Suppress stdout only during import on Wayland; on
+    # X11 pynput is a real fallback and its warnings are meaningful.
+    # Evaluated once at import time; env must be set before this module loads.
+    if os.environ.get("WAYLAND_DISPLAY"):
+        saved, sys.stdout = sys.stdout, io.StringIO()
+        try:
+            from pynput import keyboard as _kb
+        finally:
+            sys.stdout = saved
+    else:
+        from pynput import keyboard as _kb
+    return _kb
+
+
+kb = _import_pynput()
+del _import_pynput
 
 # ---------------------------------------------------------------------------
 # Key-name resolution

--- a/src/voxy/transcriber.py
+++ b/src/voxy/transcriber.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ctypes
 import logging
 from pathlib import Path
 
@@ -18,6 +19,34 @@ _log = logging.getLogger(__name__)
 
 _COMPUTE_TYPE_PRIORITY: list[str] = ["int8_float16", "float16", "float32"]
 
+# Versioned sonames ctranslate2 4.x lazy-dlopen at inference time.
+# Update _CT2_CUBLAS_VERSION when upgrading ctranslate2 to a new major.
+_CT2_CUBLAS_VERSION = "12"
+
+
+def _cuda_device_count() -> int:
+    try:
+        return ctranslate2.get_cuda_device_count()
+    except (OSError, RuntimeError) as exc:
+        _log.warning("voxy: CUDA unavailable (%s); falling back to CPU", exc)
+        return 0
+
+
+def _cuda_libs_available() -> bool:
+    """Return False if any CUDA shared library ctranslate2 needs cannot be loaded.
+
+    ctranslate2 lazy-dlopen versioned names at inference time. Probe early so
+    we fall back to CPU before loading the model, not mid-transcription.
+    """
+    v = _CT2_CUBLAS_VERSION
+    for lib in (f"libcublas.so.{v}", f"libcublasLt.so.{v}"):
+        try:
+            ctypes.CDLL(lib)
+        except OSError as exc:
+            _log.warning("voxy: CUDA library %s cannot be loaded (%s); falling back to CPU", lib, exc)
+            return False
+    return True
+
 
 def _resolve_device_and_compute(device: str) -> tuple[str, str]:
     """Return (ct2_device, compute_type) given a user device setting."""
@@ -25,14 +54,11 @@ def _resolve_device_and_compute(device: str) -> tuple[str, str]:
         _log.info("voxy: device=cpu compute_type=int8")
         return "cpu", "int8"
 
-    cuda_count = ctranslate2.get_cuda_device_count()
+    cuda_count = _cuda_device_count()
 
     if device == "cuda":
         if cuda_count == 0:
-            _log.warning(
-                "device='cuda' requested but no CUDA device found; falling back to CPU"
-            )
-            _log.info("voxy: device=cpu compute_type=int8")
+            _log.warning("device='cuda' requested but no CUDA device found; falling back to CPU")
             return "cpu", "int8"
 
     elif device == "auto":
@@ -40,7 +66,15 @@ def _resolve_device_and_compute(device: str) -> tuple[str, str]:
             _log.info("voxy: device=cpu compute_type=int8")
             return "cpu", "int8"
 
-    supported = ctranslate2.get_supported_compute_types("cuda")
+    if not _cuda_libs_available():
+        return "cpu", "int8"
+
+    try:
+        supported = ctranslate2.get_supported_compute_types("cuda")
+    except (OSError, RuntimeError) as exc:
+        _log.warning("voxy: CUDA compute type query failed (%s); falling back to CPU", exc)
+        return "cpu", "int8"
+
     for ct in _COMPUTE_TYPE_PRIORITY:
         if ct in supported:
             _log.info("voxy: device=cuda compute_type=%s", ct)
@@ -48,6 +82,11 @@ def _resolve_device_and_compute(device: str) -> tuple[str, str]:
 
     _log.info("voxy: device=cuda compute_type=float32 (fallback)")
     return "cuda", "float32"
+
+
+def _run_transcribe(model: WhisperModel, audio: npt.NDArray[np.float32]) -> str:
+    segments, _info = model.transcribe(audio, language=None, beam_size=5)
+    return "".join(segment.text for segment in segments).strip()
 
 
 class Transcriber:
@@ -97,10 +136,14 @@ class Transcriber:
         """
         if audio.size == 0:
             return ""
-        model = self._get_model()
-        segments, _info = model.transcribe(
-            audio,
-            language=None,  # auto-detect
-            beam_size=5,
-        )
-        return "".join(segment.text for segment in segments).strip()
+        try:
+            return _run_transcribe(self._get_model(), audio)
+        except (OSError, RuntimeError) as exc:
+            if self._ct2_device == "cpu":
+                raise
+            _log.warning("voxy: CUDA inference failed (%s); retrying on CPU", exc)
+            self._model = None
+            self._ct2_device = "cpu"
+            self._compute_type = "int8"
+            _log.info("voxy: permanently switched to CPU for this session")
+            return _run_transcribe(self._get_model(), audio)


### PR DESCRIPTION
## Summary
- **CUDA**: probe \`libcublas.so.{12,Lt.12}\` via \`ctypes.CDLL\` before loading the model so we fall back to CPU cleanly instead of crashing mid-transcription when ctranslate2 lazy-dlopens a missing soname. Also early-checks \`get_supported_compute_types("cuda")\` and picks the best available (\`int8_float16\` → \`float16\` → \`float32\`).
- **Hotkey**: suppress the pynput/Xlib \`xauth\` warnings emitted on Wayland when no X display is reachable — the listener still works via evdev.
- **Logs**: demote the evdev "device disconnected" warning to debug (fires routinely on USB resume).

## Test plan
- [ ] CUDA-less host: \`voxy\` starts on CPU with no traceback
- [ ] Wayland + no \`xauth\`: launch is silent
- [ ] Unplug+replug input device: log stays clean at default level

🤖 Generated with [Claude Code](https://claude.com/claude-code)