### PR TITLE
exp: split Wayland/X11 deps across flake, pyproject, and README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ progress.txt
 .claude/
 CLAUDE.md
 .agents/
+ralf-progress.txt

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Local, offline voice dictation for Linux — text appears instantly in whatever window is active. No cloud. No subscription. No audio ever leaves your machine.
 
-Built on [faster-whisper](https://github.com/SYSTRAN/faster-whisper) (2–4× faster than openai-whisper on CPU, same accuracy). Works on X11 and Wayland. Ships as a Nix flake.
+Built on [faster-whisper](https://github.com/SYSTRAN/faster-whisper) (2–4× faster than openai-whisper on CPU, same accuracy). Supports Wayland and X11 via optional display-server extras. Ships as a Nix flake.
 
 ---
 
@@ -13,13 +13,15 @@ Built on [faster-whisper](https://github.com/SYSTRAN/faster-whisper) (2–4× fa
 ### uvx (try without installing)
 
 ```bash
-uvx voxy-linux
+uvx --with "voxy-linux[wayland]" voxy-linux   # Wayland
+uvx --with "voxy-linux[x11]"     voxy-linux   # X11
 ```
 
 ### pipx (persistent isolated install)
 
 ```bash
-pipx install voxy-linux
+pipx install "voxy-linux[wayland]"   # Wayland
+pipx install "voxy-linux[x11]"       # X11
 ```
 
 ### AUR (Arch / Manjaro)
@@ -46,12 +48,12 @@ Before installing via `pip` / `pipx` / `uvx`, install the required system packag
 | Fedora | `sudo dnf install portaudio` |
 | Arch | `sudo pacman -S portaudio` |
 
-**Text insertion** (install the set that matches your display server)
+**Text insertion + cursor overlay** (install the set that matches your display server)
 
-| Display server | Packages |
-|---|---|
-| X11 | `xclip` + `xdotool` |
-| Wayland | `wl-clipboard` + `ydotool` |
+| Display server | System packages | Python extra |
+|---|---|---|
+| Wayland | `wl-clipboard` + `ydotool` + `gtk4` + `gtk4-layer-shell` | `[wayland]` |
+| X11 | `xclip` + `xdotool` | `[x11]` |
 
 > **macOS / Windows:** voxy is Linux-only. The package will install but will not run on other platforms.
 
@@ -105,7 +107,7 @@ the prompt and reuse the cached model.
 
 ```toml
 [hotkey]
-key = "right_alt"              # evdev/pynput key name
+key = "right_alt"              # evdev key name
 
 [model]
 size = "small"                 # tiny | base | small | medium | large-v3
@@ -203,6 +205,8 @@ On GPU, the compute type is selected automatically: `int8_float16` (Turing+), `f
 
 **`modelSize`** — `tiny` · `tiny.en` · `base` · `base.en` · `small` · `small.en` · `medium` · `medium.en` · `large-v1` · `large-v2` · `large-v3`
 
+**`hotkey`** — evdev key name (e.g. `right_alt`, `right_ctrl`, `f13`)
+
 **`overlayCorner`** — `top-left` · `top-right` · `bottom-left` · `bottom-right`
 
 ### Example with custom options
@@ -256,17 +260,20 @@ just deps                   # dependency counts
 ### Without just (manual)
 
 ```bash
-uv sync --extra dev
+uv sync --extra dev --extra wayland   # Wayland
+uv sync --extra dev --extra x11       # X11
 uv run python -m voxy
 uv run pytest
 uv run mypy --strict src/
 uv build
 ```
 
-### NixOS dev shell
+### Nix dev shells
 
 ```bash
-nix develop                              # enter shell with Python + all deps
+nix develop                              # Wayland shell (default)
+nix develop .#x11                        # X11 shell
+nix develop .#cuda                       # Wayland + CUDA shell
 nix develop --command pytest             # run tests
 nix develop --command mypy --strict src/ # type check
 ```

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
         cudaPy = cudaPkgs.python313;
 
         # Packages available under python3Packages.<name>
-        # faster-whisper uses quoted attr due to hyphen in name.
+        # Quoted attrs are required for names containing hyphens.
         pythonDeps = ps:
           (with ps; [
             sounddevice
@@ -37,7 +37,12 @@
             build
             twine
           ])
-          ++ [ ps."faster-whisper" ];
+          ++ [ ps."faster-whisper" ps."dbus-next" ];
+
+        # Optional deps for the Wayland cursor-overlay feature (pyproject: cursor-overlay extra).
+        # Requires system gtk4 + gtk4-layer-shell packages.
+        cursorOverlayPythonDeps = ps: with ps; [ pygobject3 pycairo ];
+        cursorOverlaySystemDeps = with pkgs; [ gtk4 gtk4-layer-shell ];
 
         # System-level CLI tools for text insertion and window detection
         systemDeps = with pkgs; [
@@ -78,6 +83,17 @@
 
           shellHook = ''
             echo "voxy cuda dev — $(python --version)"
+          '';
+        };
+
+        devShells.cursor-overlay = pkgs.mkShell {
+          packages =
+            [ (py.withPackages (ps: pythonDeps ps ++ cursorOverlayPythonDeps ps)) ]
+            ++ systemDeps
+            ++ cursorOverlaySystemDeps;
+
+          shellHook = ''
+            echo "voxy cursor-overlay dev — $(python --version)"
           '';
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -21,14 +21,12 @@
         };
         cudaPy = cudaPkgs.python313;
 
-        # Packages available under python3Packages.<name>
+        # Display-server-agnostic Python deps.
         # Quoted attrs are required for names containing hyphens.
-        pythonDeps = ps:
+        corePythonDeps = ps:
           (with ps; [
             sounddevice
             evdev
-            pynput
-            tkinter
             numpy
             mypy
             pytest
@@ -39,61 +37,61 @@
           ])
           ++ [ ps."faster-whisper" ps."dbus-next" ];
 
-        # Optional deps for the Wayland cursor-overlay feature (pyproject: cursor-overlay extra).
-        # Requires system gtk4 + gtk4-layer-shell packages.
-        cursorOverlayPythonDeps = ps: with ps; [ pygobject3 pycairo ];
-        cursorOverlaySystemDeps = with pkgs; [ gtk4 gtk4-layer-shell ];
+        # Wayland-specific deps (mirrors pyproject wayland extra).
+        # Requires system gtk4 + gtk4-layer-shell.
+        waylandPythonDeps = ps: with ps; [ pygobject3 pycairo ];
+        waylandSystemDeps = with pkgs; [ wl-clipboard ydotool gtk4 gtk4-layer-shell ];
 
-        # System-level CLI tools for text insertion and window detection
-        systemDeps = with pkgs; [
-          xclip
-          xdotool
-          xprop
-          wl-clipboard
-          ydotool
-        ];
+        # X11-specific deps (mirrors pyproject x11 extra).
+        x11PythonDeps = ps: with ps; [ pynput tkinter ];
+        x11SystemDeps = with pkgs; [ xclip xdotool xprop ];
 
-        voxy = py.pkgs.buildPythonApplication {
-          pname = "voxy-linux";
-          version = "0.1.0";
-          src = ./.;
-          format = "pyproject";
+        mkVoxy = pythonInterp: extraPythonDeps: extraSystemDeps:
+          pythonInterp.pkgs.buildPythonApplication {
+            pname = "voxy-linux";
+            version = "0.1.0";
+            src = ./.;
+            format = "pyproject";
 
-          nativeBuildInputs = with py.pkgs; [ setuptools ];
-          propagatedBuildInputs = (pythonDeps py.pkgs) ++ systemDeps;
-        };
+            nativeBuildInputs = with pythonInterp.pkgs; [ setuptools ];
+            propagatedBuildInputs =
+              (corePythonDeps pythonInterp.pkgs)
+              ++ (extraPythonDeps pythonInterp.pkgs)
+              ++ extraSystemDeps;
+          };
+
       in
       {
-        packages.default = voxy;
+        packages.default = mkVoxy py waylandPythonDeps waylandSystemDeps;
+        packages.x11 = mkVoxy py x11PythonDeps x11SystemDeps;
 
         devShells.default = pkgs.mkShell {
           packages =
-            [ (py.withPackages pythonDeps) ]
-            ++ systemDeps;
+            [ (py.withPackages (ps: corePythonDeps ps ++ waylandPythonDeps ps)) ]
+            ++ waylandSystemDeps;
 
           shellHook = ''
-            echo "voxy dev — $(python --version)"
+            echo "voxy wayland dev — $(python --version)"
+          '';
+        };
+
+        devShells.x11 = pkgs.mkShell {
+          packages =
+            [ (py.withPackages (ps: corePythonDeps ps ++ x11PythonDeps ps)) ]
+            ++ x11SystemDeps;
+
+          shellHook = ''
+            echo "voxy x11 dev — $(python --version)"
           '';
         };
 
         devShells.cuda = cudaPkgs.mkShell {
           packages =
-            [ (cudaPy.withPackages pythonDeps) ]
-            ++ systemDeps;
+            [ (cudaPy.withPackages (ps: corePythonDeps ps ++ waylandPythonDeps ps)) ]
+            ++ waylandSystemDeps;
 
           shellHook = ''
             echo "voxy cuda dev — $(python --version)"
-          '';
-        };
-
-        devShells.cursor-overlay = pkgs.mkShell {
-          packages =
-            [ (py.withPackages (ps: pythonDeps ps ++ cursorOverlayPythonDeps ps)) ]
-            ++ systemDeps
-            ++ cursorOverlaySystemDeps;
-
-          shellHook = ''
-            echo "voxy cursor-overlay dev — $(python --version)"
           '';
         };
       }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ dependencies = [
     "faster-whisper",
     "sounddevice",
     "evdev; sys_platform == 'linux'",
-    "pynput",
     "numpy",
     "dbus-next",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,9 @@ voxy = ["*.wav", "icons/*.svg"]
 
 [project.optional-dependencies]
 dev = ["pytest", "mypy", "ruff"]
-# Wayland (Hyprland) cursor overlay — needs system gtk4 + gtk4-layer-shell
-# packages too (see presetup-arch.sh).
-cursor-overlay = ["pygobject", "pycairo"]
+# Needs system gtk4 + gtk4-layer-shell packages (see presetup-arch.sh).
+wayland = ["pygobject", "pycairo"]
+x11 = ["pynput"]
 
 # mypy config lives in mypy.ini (TOML overrides not supported in this mypy version)
 


### PR DESCRIPTION
## Summary

- **`pyproject.toml`**: split display-server-specific Python deps into optional extras — `wayland` (pygobject, pycairo) and `x11` (pynput); core deps are now display-server-agnostic
- **`flake.nix`**: restructure into `corePythonDeps` + `waylandPythonDeps`/`waylandSystemDeps` + `x11PythonDeps`/`x11SystemDeps`; expose `packages.default` (Wayland), `packages.x11`, and `devShells.default` (Wayland), `devShells.x11`, `devShells.cuda`; also adds missing `dbus-next` to core
- **`README.md`**: update install commands with extras, prerequisites table, dev shell docs, and fix `evdev/pynput` config comment

## Motivation

Installing voxy on a Wayland system pulled in X11 packages (pynput/python-xlib, tkinter) and vice versa. This branch makes each display server self-contained — you only get the packages you need.

## Test plan

- [x] `nix develop` enters Wayland shell, imports `gi` (pygobject) and `cairo`
- [x] `nix develop .#x11` enters X11 shell, imports `pynput` and `tkinter`
- [x] `uv sync --extra dev --extra wayland` resolves without pynput
- [x] `uv sync --extra dev --extra x11` resolves without pygobject/pycairo
- [x] `nix build` (Wayland package) succeeds
- [x] `nix build .#x11` (X11 package) succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)