### PR TITLE
feat: hot-reload model switching via CLI and tray

### DIFF
--- a/src/voxy/__main__.py
+++ b/src/voxy/__main__.py
@@ -23,15 +23,19 @@ if (
 os.environ.setdefault("HF_HUB_DISABLE_XET", "1")
 
 import argparse
+import signal
 from pathlib import Path
 
 from voxy.app import App
 from voxy.audio import AudioRecorder, AudioFeedback
-from voxy.config import ConfigLoader, VALID_MODEL_SIZES
+from voxy.config import ConfigError, ConfigLoader, VALID_MODEL_SIZES
 from voxy.inserter import TextInserter
 from voxy.overlay import OverlayUI
 from voxy.postprocess import PostProcessor
 from voxy.transcriber import Transcriber
+
+_STATE_DIR: Path = Path.home() / ".local" / "state" / "voxy"
+_PID_FILE: Path = _STATE_DIR / "voxy.pid"
 
 _MODEL_MENU: list[tuple[str, str]] = [
     ("auto",       "detect best size for your CPU/GPU (default)"),
@@ -66,6 +70,15 @@ def _prompt_model() -> str:
         print(f"  Invalid: {raw!r}. Enter 1-{len(_MODEL_MENU)} or a model name.")
 
 
+def _write_pid() -> None:
+    _STATE_DIR.mkdir(parents=True, exist_ok=True)
+    _PID_FILE.write_text(str(os.getpid()), encoding="utf-8")
+
+
+def _remove_pid() -> None:
+    _PID_FILE.unlink(missing_ok=True)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         prog="voxy",
@@ -81,6 +94,14 @@ def main() -> None:
         action="version",
         version="voxy 0.1.0",
     )
+    parser.add_argument(
+        "--set-model",
+        metavar="SIZE",
+        help=(
+            f"Hot-swap the Whisper model in a running voxy instance. "
+            f"Valid sizes: {', '.join(sorted(VALID_MODEL_SIZES))}"
+        ),
+    )
     args = parser.parse_args()
 
     if args.daemon:
@@ -95,6 +116,30 @@ def main() -> None:
         return
 
     loader = ConfigLoader()
+
+    if args.set_model:
+        size = args.set_model
+        if size not in VALID_MODEL_SIZES:
+            print(f"voxy: invalid model size {size!r}. Valid: {sorted(VALID_MODEL_SIZES)}")
+            sys.exit(1)
+        if not _PID_FILE.exists():
+            print("voxy: no running instance (PID file not found at ~/.local/state/voxy/voxy.pid)")
+            sys.exit(1)
+        pid = int(_PID_FILE.read_text(encoding="utf-8").strip())
+        try:
+            loader.set_model_size(size)
+        except ConfigError as e:
+            print(f"voxy: {e}")
+            sys.exit(1)
+        try:
+            os.kill(pid, signal.SIGUSR1)
+            print(f"voxy: model change to {size!r} sent to PID {pid} — takes effect when idle")
+        except ProcessLookupError:
+            print(f"voxy: PID {pid} not found (stale PID file?)")
+            _PID_FILE.unlink(missing_ok=True)
+            sys.exit(1)
+        return
+
     first_run = loader.is_first_run()
     if first_run:
         chosen = _prompt_model()
@@ -150,16 +195,32 @@ def main() -> None:
         AudioFeedback(config.ui),
         key=config.hotkey.key,
         cursor_overlay=cursor_ov,
+        config_loader=loader,
+        device_setting=config.model.device,
+        language_setting=config.model.language,
     )
 
     if config.ui.tray:
         try:
             from voxy.tray import TrayIcon
-            app.set_tray(TrayIcon(on_quit=app.stop))
+
+            def _on_model_change(size: str) -> None:
+                loader.set_model_size(size)
+                app.swap_model(size)
+
+            app.set_tray(TrayIcon(
+                on_quit=app.stop,
+                on_model_change=_on_model_change,
+                get_model=lambda: app._transcriber.model_size,
+            ))
         except ImportError as e:
             print(f"voxy: tray disabled — install dbus-next ({e})", flush=True)
 
-    app.run()
+    _write_pid()
+    try:
+        app.run()
+    finally:
+        _remove_pid()
 
 
 def _shorten_home(path: Path) -> str:

--- a/src/voxy/app.py
+++ b/src/voxy/app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import signal
 import threading
 from typing import TYPE_CHECKING
 
@@ -14,6 +15,7 @@ from .postprocess import PostProcessor
 from .transcriber import Transcriber
 
 if TYPE_CHECKING:
+    from .config import ConfigLoader
     from .tray import TrayIcon
 
 
@@ -30,6 +32,11 @@ class App:
     _key: str
     _tray: TrayIcon | None
     _done: threading.Event
+    _config_loader: ConfigLoader | None
+    _device_setting: str
+    _language_setting: str
+    _reload_flag: threading.Event
+    _state: str  # "starting" | "idle" | "recording" | "processing"
 
     def __init__(
         self,
@@ -42,6 +49,9 @@ class App:
         key: str = "right_alt",
         tray: TrayIcon | None = None,
         cursor_overlay: CursorOverlay | None = None,
+        config_loader: ConfigLoader | None = None,
+        device_setting: str = "auto",
+        language_setting: str = "auto",
     ) -> None:
         self._recorder = recorder
         self._transcriber = transcriber
@@ -53,10 +63,38 @@ class App:
         self._tray = tray
         self._cursor_overlay = cursor_overlay or _NullCursorOverlay()
         self._done = threading.Event()
+        self._config_loader = config_loader
+        self._device_setting = device_setting
+        self._language_setting = language_setting
+        self._reload_flag = threading.Event()
+        self._state = "starting"
 
     def set_tray(self, tray: TrayIcon) -> None:
         """Attach a tray icon. Must be called before run()."""
         self._tray = tray
+
+    def swap_model(self, size: str) -> bool:
+        """Hot-swap the Whisper model. Refused while recording, processing, or starting.
+
+        Returns True if the swap was applied, False if skipped.
+        """
+        if self._state != "idle":
+            print(
+                f"voxy: model swap skipped — state is {self._state!r}, wait until idle",
+                flush=True,
+            )
+            return False
+        lang = None if self._language_setting == "auto" else self._language_setting
+        new_t = Transcriber(
+            model_size=size,
+            device=self._device_setting,
+            language=lang,
+        )
+        self._transcriber = new_t
+        actual = new_t.model_size
+        cached = "cached" if new_t.is_cached() else "will download on first use"
+        print(f"voxy: model → {actual} ({cached})", flush=True)
+        return True
 
     def stop(self) -> None:
         """Request graceful shutdown of the run loop."""
@@ -78,6 +116,7 @@ class App:
             on_release=self._on_release,
         )
         listener.start()
+        self._state = "idle"
         if self._tray:
             self._tray.start()
             self._tray.set_state("idle")
@@ -86,6 +125,14 @@ class App:
         mic = AudioRecorder.default_input_name()
         print(f"voxy — hold hotkey to dictate. Ctrl-C to quit. [{model} on {device}]")
         print(f"voxy: input → {mic}", flush=True)
+
+        if self._config_loader is not None:
+            signal.signal(signal.SIGUSR1, self._on_sigusr1)
+            reload_thread = threading.Thread(
+                target=self._reload_watcher, daemon=True, name="voxy-reload"
+            )
+            reload_thread.start()
+
         try:
             if self._overlay._root:
                 self._overlay.wait_loop()
@@ -99,7 +146,23 @@ class App:
             if self._tray:
                 self._tray.stop()
 
+    def _on_sigusr1(self, signum: int, frame: object) -> None:
+        self._reload_flag.set()
+
+    def _reload_watcher(self) -> None:
+        while not self._done.is_set():
+            if self._reload_flag.wait(timeout=0.5):
+                self._reload_flag.clear()
+                if self._config_loader is None:
+                    continue
+                try:
+                    cfg = self._config_loader.load()
+                    self.swap_model(cfg.model.size)
+                except Exception as e:
+                    print(f"voxy: model reload failed: {e}", flush=True)
+
     def _on_press(self) -> None:
+        self._state = "recording"
         self._overlay.show()
         self._cursor_overlay.show()
         self._feedback.play_start()
@@ -109,6 +172,8 @@ class App:
         print("voxy: recording…", flush=True)
 
     def _on_release(self) -> None:
+        self._state = "processing"
+        transcriber = self._transcriber  # snapshot — immune to concurrent swap
         audio = self._recorder.stop()
         self._overlay.processing()
         self._cursor_overlay.processing()
@@ -119,7 +184,7 @@ class App:
 
         def _pipeline() -> None:
             try:
-                text = self._transcriber.transcribe(audio)
+                text = transcriber.transcribe(audio)
                 text = self._postprocessor.process(text)
                 if text:
                     print(f"voxy: {text}", flush=True)
@@ -129,6 +194,7 @@ class App:
             except Exception as e:
                 print(f"voxy error: {e}", flush=True)
             finally:
+                self._state = "idle"
                 self._overlay.hide()
                 self._cursor_overlay.hide()
                 if self._tray:

--- a/src/voxy/config.py
+++ b/src/voxy/config.py
@@ -11,10 +11,11 @@ from typing import Any, cast
 XDG_CONFIG_PATH: Path = Path.home() / ".config" / "voxy" / "config.toml"
 VOXY_CONFIG_ENV: str = "VOXY_CONFIG"
 
-VALID_MODEL_SIZES: frozenset[str] = frozenset(
-    {"auto", "tiny", "tiny.en", "base", "base.en", "small", "small.en",
-     "medium", "medium.en", "large-v1", "large-v2", "large-v3"}
-)
+MODEL_SIZE_ORDER: list[str] = [
+    "auto", "tiny", "tiny.en", "base", "base.en", "small", "small.en",
+    "medium", "medium.en", "large-v1", "large-v2", "large-v3",
+]
+VALID_MODEL_SIZES: frozenset[str] = frozenset(MODEL_SIZE_ORDER)
 _VALID_DEVICE_OPTIONS: frozenset[str] = frozenset({"auto", "cpu", "cuda"})
 _VALID_INSERTION_METHODS: frozenset[str] = frozenset({"auto", "x11", "wayland"})
 _VALID_LOG_LEVELS: frozenset[str] = frozenset({"debug", "info", "warning", "error"})
@@ -188,6 +189,28 @@ class ConfigLoader:
             logging=_parse_logging(_as_table(raw.get("logging", {}), "logging")),
         )
 
+    def set_model_size(self, size: str) -> None:
+        """Rewrite [model] size = "..." in the config file."""
+        import re
+        if not self._config_path.exists():
+            self.write_default(model_size=size)
+            return
+        text = self._config_path.read_text(encoding="utf-8")
+        # Match `size = "..."` only inside [model] section (stops before next section)
+        new_text, n = re.subn(
+            r'(\[model\][^\[]*?)(size\s*=\s*")[^"]*(")',
+            r'\1\g<2>' + size + r'\3',
+            text,
+            count=1,
+        )
+        if n == 0:
+            # size key absent — insert immediately after [model] header
+            new_text, m = re.subn(r'(\[model\])', rf'\1\nsize = "{size}"', text, count=1)
+            if m == 0:
+                raise ConfigError(
+                    f"[model] section missing in {self._config_path}; cannot update model size"
+                )
+        self._config_path.write_text(new_text, encoding="utf-8")
 
     def write_default(self, model_size: str = "auto") -> None:
         """Create XDG dir and write a commented default config file."""

--- a/src/voxy/tray.py
+++ b/src/voxy/tray.py
@@ -2,13 +2,16 @@
 
 import asyncio
 import threading
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable
+from typing import Any, Callable
 
 from dbus_next import BusType, Variant
 from dbus_next.aio import MessageBus
 from dbus_next.service import ServiceInterface, dbus_property, method, signal
 from dbus_next.constants import PropertyAccess
+
+from .config import MODEL_SIZE_ORDER
 
 _WATCHER_BUS: str = "org.kde.StatusNotifierWatcher"
 _WATCHER_PATH: str = "/StatusNotifierWatcher"
@@ -25,6 +28,34 @@ _STATE_ICONS: dict[str, str] = {
     "recording": _ICON_RECORDING,
     "processing": _ICON_PROCESSING,
 }
+
+
+@dataclass
+class MenuItem:
+    id: int
+    label: str = ""
+    callback: Callable[[], None] | None = None
+    enabled: bool = True
+    item_type: str = "standard"       # "standard" | "separator"
+    toggle_type: str = ""             # "" | "checkmark" | "radio"
+    toggle_state_fn: Callable[[], int] | None = None
+    children: list["MenuItem"] = field(default_factory=list)
+
+    def props(self) -> dict[str, Variant]:
+        p: dict[str, Variant] = {}
+        if self.item_type == "separator":
+            p["type"] = Variant("s", "separator")
+            return p
+        p["label"] = Variant("s", self.label)
+        p["enabled"] = Variant("b", self.enabled)
+        p["visible"] = Variant("b", True)
+        if self.children:
+            p["children-display"] = Variant("s", "submenu")
+        if self.toggle_type:
+            p["toggle-type"] = Variant("s", self.toggle_type)
+            state = self.toggle_state_fn() if self.toggle_state_fn else 0
+            p["toggle-state"] = Variant("i", state)
+        return p
 
 
 class _StatusNotifierItem(ServiceInterface):
@@ -123,10 +154,33 @@ class _StatusNotifierItem(ServiceInterface):
 class _DBusMenu(ServiceInterface):
     """com.canonical.dbusmenu — context menu shown by waybar/KDE."""
 
-    def __init__(self, items: list[tuple[int, str, Callable[[], None]]]) -> None:
+    def __init__(self, items: list[MenuItem]) -> None:
         super().__init__("com.canonical.dbusmenu")
-        self._items = items  # (id, label, callback) — id 0 reserved for root
+        self._items = items
         self._revision = 1
+
+    def _find(self, target_id: int, items: list[MenuItem] | None = None) -> MenuItem | None:
+        for item in (items if items is not None else self._items):
+            if item.id == target_id:
+                return item
+            found = self._find(target_id, item.children)
+            if found:
+                return found
+        return None
+
+    def _all(self, items: list[MenuItem] | None = None) -> list[MenuItem]:
+        result: list[MenuItem] = []
+        for item in (items if items is not None else self._items):
+            result.append(item)
+            result.extend(self._all(item.children))
+        return result
+
+    def _to_variant(self, item: MenuItem, depth: int) -> Variant:
+        children: list[Any] = []
+        if depth != 0 and item.children:
+            next_depth = depth - 1 if depth > 0 else -1
+            children = [self._to_variant(c, next_depth) for c in item.children]
+        return Variant("(ia{sv}av)", [item.id, item.props(), children])
 
     @dbus_property(access=PropertyAccess.READ)
     def Version(self) -> "u":  # type: ignore[name-defined]  # noqa: F722
@@ -148,43 +202,35 @@ class _DBusMenu(ServiceInterface):
     def GetLayout(
         self, parentId: "i", recursionDepth: "i", propertyNames: "as"  # type: ignore[name-defined]  # noqa: F722, F821
     ) -> "u(ia{sv}av)":  # type: ignore[name-defined]  # noqa: F722
-        if parentId != 0:
+        depth = recursionDepth if recursionDepth >= 0 else 100
+        if parentId == 0:
+            children = [self._to_variant(item, depth - 1) for item in self._items]
+            return [self._revision, [0, {"children-display": Variant("s", "submenu")}, children]]
+        item = self._find(parentId)
+        if item is None:
             return [self._revision, [parentId, {}, []]]
-        children: list = []
-        if recursionDepth != 0:
-            for item_id, label, _ in self._items:
-                props = {"label": Variant("s", label)}
-                children.append(Variant("(ia{sv}av)", [item_id, props, []]))
-        root_props = {"children-display": Variant("s", "submenu")}
-        return [self._revision, [0, root_props, children]]
+        next_depth = depth - 1 if depth > 0 else -1
+        children = [self._to_variant(c, next_depth) for c in item.children]
+        return [self._revision, [parentId, item.props(), children]]
 
     @method()
     def GetGroupProperties(
         self, ids: "ai", propertyNames: "as"  # type: ignore[name-defined]  # noqa: F722, F821
     ) -> "a(ia{sv})":  # type: ignore[name-defined]  # noqa: F722
-        out = []
-        for item_id, label, _ in self._items:
-            if ids and item_id not in ids:
-                continue
-            props = {
-                "label": Variant("s", label),
-                "enabled": Variant("b", True),
-                "visible": Variant("b", True),
-            }
-            out.append([item_id, props])
-        return out
+        all_items = self._all()
+        return [
+            [item.id, item.props()]
+            for item in all_items
+            if not ids or item.id in ids
+        ]
 
     @method()
     def GetProperty(self, id: "i", name: "s") -> "v":  # type: ignore[name-defined]  # noqa: F722, F821
         if id == 0 and name == "children-display":
             return Variant("s", "submenu")
-        for item_id, label, _ in self._items:
-            if item_id != id:
-                continue
-            if name == "label":
-                return Variant("s", label)
-            if name in ("enabled", "visible"):
-                return Variant("b", True)
+        item = self._find(id)
+        if item:
+            return item.props().get(name, Variant("s", ""))
         return Variant("s", "")
 
     @method()
@@ -193,37 +239,36 @@ class _DBusMenu(ServiceInterface):
     ) -> None:
         if eventId != "clicked":
             return
-        for item_id, _, cb in self._items:
-            if item_id == id:
-                try:
-                    cb()
-                except Exception:
-                    pass
-                return
+        item = self._find(id)
+        if item and item.callback:
+            try:
+                item.callback()
+            except Exception:
+                pass
 
     @method()
     def EventGroup(
         self, events: "a(isvu)"  # type: ignore[name-defined]  # noqa: F722, F821
     ) -> "ai":  # type: ignore[name-defined]  # noqa: F722
-        known = {item_id for item_id, _, _ in self._items}
+        known = {item.id for item in self._all()}
         not_found: list[int] = []
         for ev in events:
-            ev_id = ev[0]
-            if ev_id not in known:
-                not_found.append(ev_id)
+            if ev[0] not in known:
+                not_found.append(ev[0])
                 continue
-            self.Event(ev_id, ev[1], ev[2], ev[3])
+            self.Event(ev[0], ev[1], ev[2], ev[3])
         return not_found
 
     @method()
     def AboutToShow(self, id: "i") -> "b":  # type: ignore[name-defined]  # noqa: F722, F821
-        return False
+        # Always true so the client re-fetches layout (picks up fresh checkmark states).
+        return True
 
     @method()
     def AboutToShowGroup(
         self, ids: "ai"  # type: ignore[name-defined]  # noqa: F722, F821
     ) -> "aiai":  # type: ignore[name-defined]  # noqa: F722
-        return [[], []]
+        return [list(ids), []]
 
     @signal()
     def ItemsPropertiesUpdated(
@@ -245,8 +290,15 @@ class _DBusMenu(ServiceInterface):
 class TrayIcon:
     """Tray icon running an SNI service in a dedicated asyncio thread."""
 
-    def __init__(self, on_quit: Callable[[], None]) -> None:
+    def __init__(
+        self,
+        on_quit: Callable[[], None],
+        on_model_change: Callable[[str], None] | None = None,
+        get_model: Callable[[], str] | None = None,
+    ) -> None:
         self._on_quit = on_quit
+        self._on_model_change = on_model_change
+        self._get_model = get_model
         self._loop: asyncio.AbstractEventLoop | None = None
         self._thread: threading.Thread | None = None
         self._sni: _StatusNotifierItem | None = None
@@ -298,12 +350,31 @@ class TrayIcon:
             unique = bus.unique_name
 
             sni = _StatusNotifierItem()
-            menu = _DBusMenu(
-                items=[
-                    (1, "voxy", lambda: None),
-                    (2, "Quit", self._on_quit),
-                ]
-            )
+
+            on_model_change = self._on_model_change
+            get_model = self._get_model
+
+            model_children: list[MenuItem] = []
+            if on_model_change is not None and get_model is not None:
+                for i, size in enumerate(MODEL_SIZE_ORDER):
+                    model_children.append(MenuItem(
+                        id=100 + i,
+                        label=size,
+                        callback=lambda sz=size: on_model_change(sz),
+                        toggle_type="checkmark",
+                        toggle_state_fn=lambda sz=size: 1 if get_model() == sz else 0,
+                    ))
+
+            items: list[MenuItem] = [
+                MenuItem(id=1, label="voxy", enabled=False),
+                MenuItem(id=2, item_type="separator"),
+            ]
+            if model_children:
+                items.append(MenuItem(id=3, label="Model", children=model_children))
+                items.append(MenuItem(id=4, item_type="separator"))
+            items.append(MenuItem(id=5, label="Quit", callback=self._on_quit))
+
+            menu = _DBusMenu(items=items)
             bus.export(_ITEM_PATH, sni)
             bus.export(_MENU_PATH, menu)
 


### PR DESCRIPTION
Closes #41

## Summary

- **CLI**: `voxy --set-model <size>` writes config + sends SIGUSR1 to running process; swap applies within ~0.5 s
- **Tray**: "Model" submenu with all 12 sizes, live checkmark on active model, click to switch
- **Guard rail**: swap refused while `recording`, `processing`, or `starting`

## Changes

### `config.py`
- `MODEL_SIZE_ORDER` is now the single source of truth; `VALID_MODEL_SIZES = frozenset(MODEL_SIZE_ORDER)` — eliminates silent drift risk
- `ConfigLoader.set_model_size(size)`: rewrites `[model] size = "..."` in-place with regex; raises `ConfigError` if `[model]` section missing

### `app.py`
- `App.swap_model(size) -> bool`: creates new `Transcriber` lazily, guards on `_state != "idle"`
- `_state` field tracks `"starting" | "idle" | "recording" | "processing"` — transitions wired into `_on_press`, `_on_release`, `_pipeline` finally block, and `run()`
- SIGUSR1 handler sets a `threading.Event`; watcher thread drains it and calls `swap_model`
- `_on_release` snapshots `self._transcriber` into a local before spawning `_pipeline` — eliminates TOCTOU race where concurrent swap could affect in-flight transcription

### `tray.py`
- `MenuItem` dataclass with `toggle_state_fn: Callable[[], int] | None` for dynamic checkmarks
- `_DBusMenu` rewritten to support full item tree (nested submenus, separators, checkmarks); `AboutToShow` returns `True` so client re-fetches layout on open — ensures checkmark reflects current model without emitting `LayoutUpdated`
- `TrayIcon` accepts `on_model_change` and `get_model` callbacks; builds "Model" submenu conditionally

### `__main__.py`
- `--set-model SIZE` arg: validates, calls `set_model_size`, sends SIGUSR1, prints `"takes effect when idle"`
- PID file written to `~/.local/state/voxy/voxy.pid` before `app.run()`, removed in `finally`
- Tray wired with `_on_model_change` callback (writes config + swaps model) and `get_model` lambda

## Test plan

- [x] All 22 existing tests pass
- [x] mypy clean on all 4 changed files
- [ ] Manual: `voxy --set-model small` while idle → model changes within 0.5 s
- [ ] Manual: `voxy --set-model small` while recording → prints "swap skipped", no change
- [ ] Manual: tray "Model" submenu checkmark reflects active model after CLI switch
- [ ] Manual: tray model click persists to config.toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)