### PR TITLE
fix(nixos): voxy.service fails on NixOS (#43)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,7 @@
             sounddevice
             evdev
             numpy
+            pynput
             mypy
             pytest
             ruff
@@ -43,7 +44,7 @@
         waylandSystemDeps = with pkgs; [ wl-clipboard ydotool gtk4 gtk4-layer-shell ];
 
         # X11-specific deps (mirrors pyproject x11 extra).
-        x11PythonDeps = ps: with ps; [ pynput tkinter python-xlib pycairo ];
+        x11PythonDeps = ps: with ps; [ tkinter xlib pycairo ];
         x11SystemDeps = with pkgs; [ xclip xdotool xprop ];
 
         mkVoxy = pythonInterp: extraPythonDeps: extraSystemDeps:

--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -41,11 +41,22 @@ let
 
   configFile = pkgs.writeText "voxy-config.toml" configToml;
 
-  voxyPkg = self.packages.${pkgs.system}.default;
+  voxyPkgs = self.packages.${pkgs.system};
 in
 {
   options.services.voxy = {
     enable = lib.mkEnableOption "voxy local offline voice dictation";
+
+    displayServer = lib.mkOption {
+      type = lib.types.enum [ "wayland" "x11" ];
+      default = "wayland";
+      description = ''
+        Display server backend to use.
+        Set to <literal>x11</literal> when running an X11 desktop session;
+        the default <literal>wayland</literal> build will fail on X11 because
+        it depends on gtk4-layer-shell and wl-clipboard.
+      '';
+    };
 
     hotkey = lib.mkOption {
       type = lib.types.str;
@@ -77,9 +88,20 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    environment.systemPackages = [ voxyPkg ];
+    assertions = [
+      {
+        assertion = cfg.displayServer == "wayland" || cfg.displayServer == "x11";
+        message = "services.voxy.displayServer must be \"wayland\" or \"x11\".";
+      }
+    ];
 
-    systemd.user.services.voxy = {
+    environment.systemPackages = [
+      (if cfg.displayServer == "x11" then voxyPkgs.x11 else voxyPkgs.default)
+    ];
+
+    systemd.user.services.voxy = let
+      pkg = if cfg.displayServer == "x11" then voxyPkgs.x11 else voxyPkgs.default;
+    in {
       description = "voxy — local offline voice dictation for Linux";
       wantedBy = [ "graphical-session.target" ];
       partOf   = [ "graphical-session.target" ];
@@ -89,7 +111,7 @@ in
       };
       serviceConfig = {
         Type = "simple";
-        ExecStart = "${voxyPkg}/bin/voxy";
+        ExecStart = "${pkg}/bin/voxy";
         Restart = "on-failure";
       };
     };

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "sounddevice",
     "evdev; sys_platform == 'linux'",
     "numpy",
+    "pynput; sys_platform == 'linux'",
     "dbus-next",
 ]
 
@@ -34,7 +35,7 @@ voxy = ["*.wav", "icons/*.svg"]
 dev = ["pytest", "mypy", "ruff"]
 # Needs system gtk4 + gtk4-layer-shell packages (see presetup-arch.sh).
 wayland = ["pygobject", "pycairo"]
-x11 = ["pynput", "python-xlib", "pycairo"]
+x11 = ["python-xlib", "pycairo"]
 
 # mypy config lives in mypy.ini (TOML overrides not supported in this mypy version)
 

--- a/src/voxy/hotkey.py
+++ b/src/voxy/hotkey.py
@@ -14,24 +14,27 @@ import evdev
 import evdev.ecodes as ecodes
 
 
-def _import_pynput():  # type: ignore[return]
-    # On Wayland, pynput falls back to its X11 backend but xauth is empty/missing,
-    # causing a noisy print(). Suppress stdout only during import on Wayland; on
-    # X11 pynput is a real fallback and its warnings are meaningful.
-    # Evaluated once at import time; env must be set before this module loads.
+def _try_import_pynput() -> object | None:
+    # Suppress the noisy "XDG_RUNTIME_DIR not set" / xauth print that pynput
+    # emits on Wayland when its X11 backend can't connect.
     if os.environ.get("WAYLAND_DISPLAY"):
         saved, sys.stdout = sys.stdout, io.StringIO()
         try:
             from pynput import keyboard as _kb
+            return _kb
+        except ImportError:
+            return None
         finally:
             sys.stdout = saved
     else:
-        from pynput import keyboard as _kb
-    return _kb
+        try:
+            from pynput import keyboard as _kb
+            return _kb
+        except ImportError:
+            return None
 
 
-kb = _import_pynput()
-del _import_pynput
+_kb_module = _try_import_pynput()
 
 # ---------------------------------------------------------------------------
 # Key-name resolution
@@ -48,10 +51,10 @@ def _evdev_code(key: str) -> int | None:
     return _EVDEV_KEY_MAP.get(key.lower().replace("_", "").replace(" ", ""))
 
 
-# All pynput Key names, exact match first
-_PYNPUT_KEY_NAMES: set[str] = {
-    name for name in dir(kb.Key) if not name.startswith("_")
-}
+_PYNPUT_KEY_NAMES: set[str] = (
+    {name for name in dir(_kb_module.Key) if not name.startswith("_")}
+    if _kb_module is not None else set()
+)
 
 
 def _normalise_for_pynput(key: str) -> str:
@@ -70,18 +73,20 @@ def _normalise_for_pynput(key: str) -> str:
     return key.lower()
 
 
-def _pynput_key(key: str) -> kb.Key | kb.KeyCode:
+def _pynput_key(key: str) -> object:
+    assert _kb_module is not None
     normalised = _normalise_for_pynput(key)
-    pynput_attr = getattr(kb.Key, normalised, None)
+    pynput_attr = getattr(_kb_module.Key, normalised, None)
     if pynput_attr is not None:
         return pynput_attr
-    return kb.KeyCode.from_char(key)
+    return _kb_module.KeyCode.from_char(key)
 
 
-def _keys_match(key: kb.Key | kb.KeyCode | None, target: kb.Key | kb.KeyCode) -> bool:
-    if isinstance(target, kb.Key):
+def _keys_match(key: object, target: object) -> bool:
+    assert _kb_module is not None
+    if isinstance(target, _kb_module.Key):
         return bool(key == target)
-    if isinstance(target, kb.KeyCode) and isinstance(key, kb.KeyCode):
+    if isinstance(target, _kb_module.KeyCode) and isinstance(key, _kb_module.KeyCode):
         return bool(key.char == target.char)
     return False
 
@@ -219,22 +224,27 @@ class HotkeyListener:
     # ------------------------------------------------------------------
 
     def _run_pynput(self) -> None:
+        if _kb_module is None:
+            raise RuntimeError(
+                "pynput is not installed; voxy cannot fall back from evdev.\n"
+                "  Install pynput or ensure the user is in the 'input' group so evdev works."
+            )
         target = _pynput_key(self._key)
         pressed = False
 
-        def on_press(key: kb.Key | kb.KeyCode | None) -> None:
+        def on_press(key: object) -> None:
             nonlocal pressed
             if not pressed and _keys_match(key, target):
                 pressed = True
                 self._on_press()
 
-        def on_release(key: kb.Key | kb.KeyCode | None) -> None:
+        def on_release(key: object) -> None:
             nonlocal pressed
             if pressed and _keys_match(key, target):
                 pressed = False
                 self._on_release()
 
-        with kb.Listener(on_press=on_press, on_release=on_release) as listener:
+        with _kb_module.Listener(on_press=on_press, on_release=on_release) as listener:
             self._stop_event.wait()
             listener.stop()
 


### PR DESCRIPTION
## Summary

- **`flake.nix`**: promote `pynput` from `x11PythonDeps` to `corePythonDeps` so the Wayland build includes it (it was absent, causing `ModuleNotFoundError` at startup)
- **`nixos-module.nix`**: add `displayServer` option (`"wayland"` | `"x11"`, default `"wayland"`) so X11 users get `packages.x11` instead of the Wayland build
- **`pyproject.toml`**: promote `pynput` to core dependencies (it is imported unconditionally at module load time, not just for X11)
- **`hotkey.py`**: wrap the pynput import in `try/except ImportError` so a missing pynput no longer crashes the app on startup — `_run_pynput()` raises a clear `RuntimeError` only if the evdev fallback is actually needed and pynput is still absent

## Root causes

1. `nixos-module.nix` always referenced `packages.default` (Wayland build) — X11 users got the wrong package with missing `xlib`, `tkinter`, etc.
2. `pynput` was in `x11PythonDeps` only, so the Wayland build shipped without it even though `hotkey.py` imports it unconditionally at module level.

## Test plan

- [ ] `nix build .#` — Wayland build succeeds and `pynput` is in the closure
- [ ] `nix build .#x11` — X11 build succeeds
- [ ] `nix run .#` on a Wayland session — service starts, hotkey works via evdev
- [ ] NixOS module with `services.voxy.displayServer = "x11"` selects the x11 package
- [ ] App starts cleanly on a build without pynput (evdev path only, no crash on import)

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)