### PR TITLE
docs: explain how and when the Hyprland cursor-shape-emit plugin is installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ The cursor overlay normally just draws a green frame around the pointer.
 To make the overlay also **mirror the live system cursor shape** (I-beam
 in text fields, hand on links, resize cursors at window edges, …), voxy
 ships a small Hyprland plugin in
-[`hyprland-plugin/cursor-shape-emit/`](hyprland-plugin/cursor-shape-emit).
+[`hyprland-plugin/cursor-shape-emit/`](hyprland-plugin/cursor-shape-emit/).
 It hooks `CCursorManager::setCursorFromName` and
 `CInputManager::onMouseMoved` and re-emits them as Hyprland IPC events
 (`cursorshape>>name`, `cursormove>>x,y`) that voxy reads over `socket2`.
@@ -205,28 +205,35 @@ true`. On every startup `build_cursor_overlay()` calls
 ([`src/voxy/cursor_overlay.py`](src/voxy/cursor_overlay.py)), which:
 
 1. Looks for `~/.local/share/hyprland/plugins/cursor-shape-emit.so`.
-2. Skips if the file is missing — the overlay still works, just without
-   shape-aware cursor outlines.
+2. Skips if the file is missing (debug log, no error) — the overlay
+   still works, just without shape-aware cursor outlines.
 3. Otherwise asks `hyprctl plugin list` whether it's already loaded;
    if not, runs `hyprctl plugin load <path>`.
 
-There is **no auto-build**: `pip` / `pipx` / `uvx` / the AUR package /
-the Nix flake all install only the Python code. Until you build and
-install the `.so` yourself, voxy silently runs without it.
+There is **no auto-build**: `pip` / `pipx` / `uvx` and the AUR package
+all install only the Python code, so until you build and install the
+`.so` yourself voxy runs without it.
 
-**How to install it.** Hyprland headers are required (`pacman -S
-hyprland` on Arch — adjust for your distro):
+**How to install it.** You need the repo checked out and Hyprland's
+development headers on the system (`pacman -S hyprland` on Arch —
+adjust for your distro):
 
 ```bash
-cd hyprland-plugin/cursor-shape-emit
+git clone https://github.com/samanddima/voxy-linux
+cd voxy-linux/hyprland-plugin/cursor-shape-emit
 make           # produces cursor-shape-emit.so
 make install   # copies to ~/.local/share/hyprland/plugins/
 ```
 
 The next time voxy starts (or restart the user service:
-`systemctl --user restart voxy`) it will load the plugin and the
-cursor-shape feature lights up. Verify with `hyprctl plugin list` —
-`cursor-shape-emit` should appear.
+`systemctl --user restart voxy`) it will load the plugin. Verify with
+`hyprctl plugin list` — `cursor-shape-emit` should appear.
+
+> **NixOS users:** the Nix flake doesn't build this plugin and
+> `hyprctl plugin load` against a hand-built `.so` isn't the right
+> workflow on NixOS. Use Hyprland's own plugin support
+> ([wiki.hyprland.org/Plugins/Using-Plugins](https://wiki.hyprland.org/Plugins/Using-Plugins/))
+> to package and load `cursor-shape-emit` from `hyprland-plugin/cursor-shape-emit/`.
 
 **To uninstall:** `hyprctl plugin unload
 ~/.local/share/hyprland/plugins/cursor-shape-emit.so` and delete the

--- a/README.md
+++ b/README.md
@@ -188,6 +188,50 @@ cursor overlay is active.
 See [docs/adr/0001-cursor-overlay.md](docs/adr/0001-cursor-overlay.md)
 for the design rationale.
 
+### Hyprland plugin (optional)
+
+The cursor overlay normally just draws a green frame around the pointer.
+To make the overlay also **mirror the live system cursor shape** (I-beam
+in text fields, hand on links, resize cursors at window edges, …), voxy
+ships a small Hyprland plugin in
+[`hyprland-plugin/cursor-shape-emit/`](hyprland-plugin/cursor-shape-emit).
+It hooks `CCursorManager::setCursorFromName` and
+`CInputManager::onMouseMoved` and re-emits them as Hyprland IPC events
+(`cursorshape>>name`, `cursormove>>x,y`) that voxy reads over `socket2`.
+
+**When it's used.** Only on Hyprland, only when `[ui] cursor_overlay =
+true`. On every startup `build_cursor_overlay()` calls
+`_ensure_cursor_plugin()`
+([`src/voxy/cursor_overlay.py`](src/voxy/cursor_overlay.py)), which:
+
+1. Looks for `~/.local/share/hyprland/plugins/cursor-shape-emit.so`.
+2. Skips if the file is missing — the overlay still works, just without
+   shape-aware cursor outlines.
+3. Otherwise asks `hyprctl plugin list` whether it's already loaded;
+   if not, runs `hyprctl plugin load <path>`.
+
+There is **no auto-build**: `pip` / `pipx` / `uvx` / the AUR package /
+the Nix flake all install only the Python code. Until you build and
+install the `.so` yourself, voxy silently runs without it.
+
+**How to install it.** Hyprland headers are required (`pacman -S
+hyprland` on Arch — adjust for your distro):
+
+```bash
+cd hyprland-plugin/cursor-shape-emit
+make           # produces cursor-shape-emit.so
+make install   # copies to ~/.local/share/hyprland/plugins/
+```
+
+The next time voxy starts (or restart the user service:
+`systemctl --user restart voxy`) it will load the plugin and the
+cursor-shape feature lights up. Verify with `hyprctl plugin list` —
+`cursor-shape-emit` should appear.
+
+**To uninstall:** `hyprctl plugin unload
+~/.local/share/hyprland/plugins/cursor-shape-emit.so` and delete the
+file. voxy will fall back to the plain green frame on the next launch.
+
 ---
 
 **Terminal paste:** when a terminal emulator is the active window (alacritty, kitty, ghostty, gnome-terminal, konsole), voxy automatically uses Ctrl+Shift+V instead of Ctrl+V. No configuration needed.

--- a/hyprland-plugin/cursor-shape-emit/README.md
+++ b/hyprland-plugin/cursor-shape-emit/README.md
@@ -1,0 +1,63 @@
+# cursor-shape-emit
+
+Hyprland plugin that re-emits cursor shape and position changes as
+Hyprland IPC events so voxy's cursor overlay can mirror the live system
+cursor shape (I-beam, hand, resize, …) while recording.
+
+## Events
+
+| Event | Payload | When |
+|---|---|---|
+| `cursorshape>>name` | xcursor name (`default`, `text`, `pointer`, `nesw-resize`, …) | Hyprland calls `CCursorManager::setCursorFromName` |
+| `cursormove>>x,y` | global cursor coords | Hyprland calls `CInputManager::onMouseMoved` |
+
+A `hyprctl dispatch cursorshapequery` is also registered so a freshly
+connected client can re-request the current shape.
+
+## When voxy uses it
+
+The plugin is **optional**. voxy only consults it when:
+
+- you're on Hyprland (Wayland), AND
+- `[ui] cursor_overlay = true` in `~/.config/voxy/config.toml`.
+
+Without the plugin the overlay still draws a green frame around the
+pointer; with the plugin it additionally outlines whichever cursor
+shape Hyprland is currently rendering.
+
+On every startup voxy runs `_ensure_cursor_plugin()`
+([`src/voxy/cursor_overlay.py`](../../src/voxy/cursor_overlay.py)) which:
+
+1. Checks for `~/.local/share/hyprland/plugins/cursor-shape-emit.so`.
+2. If present, queries `hyprctl plugin list` and runs
+   `hyprctl plugin load <path>` when not already loaded.
+3. If absent, logs a debug line and continues — no error.
+
+Nothing in the Python install path (pip, pipx, uvx, AUR, Nix flake)
+builds or installs this `.so`. You build it yourself, once, against
+your running Hyprland's headers.
+
+## Build & install
+
+Requires Hyprland's development headers (e.g. `pacman -S hyprland`).
+The plugin must be rebuilt whenever Hyprland is upgraded — its ABI is
+not stable across versions.
+
+```bash
+make           # produces cursor-shape-emit.so
+make install   # copies to ~/.local/share/hyprland/plugins/
+```
+
+Then restart voxy (`systemctl --user restart voxy` if running as a
+user service) and verify with:
+
+```bash
+hyprctl plugin list   # cursor-shape-emit 1.1 should appear
+```
+
+## Uninstall
+
+```bash
+hyprctl plugin unload ~/.local/share/hyprland/plugins/cursor-shape-emit.so
+rm ~/.local/share/hyprland/plugins/cursor-shape-emit.so
+```

--- a/hyprland-plugin/cursor-shape-emit/README.md
+++ b/hyprland-plugin/cursor-shape-emit/README.md
@@ -33,15 +33,21 @@ On every startup voxy runs `_ensure_cursor_plugin()`
    `hyprctl plugin load <path>` when not already loaded.
 3. If absent, logs a debug line and continues — no error.
 
-Nothing in the Python install path (pip, pipx, uvx, AUR, Nix flake)
-builds or installs this `.so`. You build it yourself, once, against
-your running Hyprland's headers.
+Nothing in the Python install path (pip, pipx, uvx, AUR) builds or
+installs this `.so`. You build it yourself, once, against your running
+Hyprland's headers.
+
+> **NixOS:** the Nix flake doesn't build this plugin and `hyprctl
+> plugin load` against a hand-built `.so` isn't the right workflow on
+> NixOS. Use Hyprland's own plugin support
+> ([wiki.hyprland.org/Plugins/Using-Plugins](https://wiki.hyprland.org/Plugins/Using-Plugins/))
+> to package and load this directory.
 
 ## Build & install
 
-Requires Hyprland's development headers (e.g. `pacman -S hyprland`).
-The plugin must be rebuilt whenever Hyprland is upgraded — its ABI is
-not stable across versions.
+Requires the repo checked out and Hyprland's development headers
+(e.g. `pacman -S hyprland`). The plugin must be rebuilt whenever
+Hyprland is upgraded — its ABI is not stable across versions.
 
 ```bash
 make           # produces cursor-shape-emit.so
@@ -52,7 +58,7 @@ Then restart voxy (`systemctl --user restart voxy` if running as a
 user service) and verify with:
 
 ```bash
-hyprctl plugin list   # cursor-shape-emit 1.1 should appear
+hyprctl plugin list   # cursor-shape-emit should appear
 ```
 
 ## Uninstall


### PR DESCRIPTION
The README and the plugin folder didn't mention that voxy ships a
Hyprland plugin, that no install path builds it for you, or that voxy
auto-loads it via hyprctl on startup when the .so is found at
~/.local/share/hyprland/plugins/. Document this in both spots so users
know it's optional, when it kicks in, and how to build/install it.