### PR TITLE
fix(kde): drop input group guard, route KDE Wayland to XWayland

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,23 +6,41 @@ pkgdesc="Local offline voice dictation for Linux (push-to-talk, faster-whisper)"
 arch=('x86_64' 'aarch64')
 url="https://github.com/samanddima/voxy-linux"
 license=('MIT')
-depends=('python' 'portaudio' 'python-pip')
+# Python deps bundled in /opt/voxy-linux venv — no AUR packages required.
+depends=(
+    'python'
+    'portaudio'
+    'tk'
+)
 optdepends=(
     'xclip: X11 clipboard support'
     'xdotool: X11 paste simulation'
-    'wl-clipboard: Wayland clipboard support'
-    'ydotool: Wayland paste simulation'
+    'wl-clipboard: Wayland/KDE clipboard support'
+    'ydotool: Wayland text insertion (non-KDE; requires input group)'
+    'gtk4: cursor overlay (Wayland)'
+    'gtk4-layer-shell: cursor overlay (Wayland)'
+    'python-gobject: cursor overlay'
+    'python-cairo: cursor overlay'
 )
-makedepends=('python-build' 'python-installer' 'python-wheel')
-source=("https://files.pythonhosted.org/packages/source/v/$pkgname/$pkgname-$pkgver.tar.gz")
+makedepends=('uv')
+_pyname="${pkgname//-/_}"
+_wheel="${_pyname}-${pkgver}-py3-none-any.whl"
+noextract=("$_wheel")
+source=("$_wheel")
 sha256sums=('SKIP')
 
-build() {
-    cd "$srcdir/$pkgname-$pkgver"
-    python -m build --wheel --no-isolation
-}
-
 package() {
-    cd "$srcdir/$pkgname-$pkgver"
-    python -m installer --destdir="$pkgdir" dist/*.whl
+    # Isolated venv at final install path — bundles all Python deps.
+    python -m venv "$pkgdir/opt/$pkgname"
+
+    uv pip install \
+        --python "$pkgdir/opt/$pkgname/bin/python" \
+        "$srcdir/$_wheel"
+
+    # Strip $pkgdir prefix from shebangs so scripts work after install.
+    find "$pkgdir/opt/$pkgname/bin" -type f -executable \
+        -exec sed -i "s|$pkgdir||g" {} \;
+
+    install -dm755 "$pkgdir/usr/bin"
+    ln -s "/opt/$pkgname/bin/voxy" "$pkgdir/usr/bin/voxy"
 }

--- a/README.md
+++ b/README.md
@@ -19,15 +19,20 @@ uvx --with "voxy-linux[x11]"     voxy-linux   # X11
 
 ### pipx (persistent isolated install)
 
+On Arch, run `presetup-arch.sh` first to install required system packages (`portaudio`, `wl-clipboard`, `ydotool`, etc.) — pipx handles the Python deps itself, bypassing the AUR limitation.
+
 ```bash
+./presetup-arch.sh   # Arch only, once
 pipx install "voxy-linux[wayland]"   # Wayland
 pipx install "voxy-linux[x11]"       # X11
 ```
 
 ### AUR (Arch / Manjaro)
 
+Requires an AUR helper — several Python dependencies (`python-faster-whisper`, `python-sounddevice`, `python-pynput`, `python-dbus-next`) are AUR-only and plain `pacman` cannot resolve them.
+
 ```bash
-yay -S voxy-linux
+yay -S voxy-linux   # or: paru -S voxy-linux
 ```
 
 ### NixOS
@@ -48,12 +53,13 @@ Before installing via `pip` / `pipx` / `uvx`, install the required system packag
 | Fedora | `sudo dnf install portaudio` |
 | Arch | `sudo pacman -S portaudio` |
 
-**Text insertion + cursor overlay** (install the set that matches your display server)
+**Text insertion** (install the set that matches your desktop)
 
-| Display server | System packages | Python extra |
+| Desktop | System packages | Notes |
 |---|---|---|
-| Wayland | `wl-clipboard` + `ydotool` + `gtk4` + `gtk4-layer-shell` | `[wayland]` |
-| X11 | `xclip` + `xdotool` | `[x11]` |
+| KDE Plasma (Wayland) | `xclip` + `xdotool` | Uses XWayland — no daemon or group membership needed |
+| Wayland (other) | `wl-clipboard` + `ydotool` | Enable daemon: `systemctl --user enable --now ydotool` |
+| X11 | `xclip` + `xdotool` | |
 
 **Cursor overlay** (optional, Hyprland only — see [Cursor overlay](#cursor-overlay))
 

--- a/justfiles/dev.just
+++ b/justfiles/dev.just
@@ -29,6 +29,43 @@ build:
 install: build
     pipx install --force dist/voxy_linux-*.whl
 
+# Build Arch Linux package (.pkg.tar.zst) into dist/
+# Version from latest git tag (YYYY.M.D.N format); bumps N if tag exists for today
+build-arch:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    REPO_ROOT=$(git rev-parse --show-toplevel)
+    TODAY=$(date +%Y.%-m.%-d)
+    LATEST=$(git tag --sort=-version:refname | grep -E '^[0-9]{4}\.' | head -1 || true)
+    if [[ "$LATEST" == "$TODAY".* ]]; then
+        N=$(echo "$LATEST" | awk -F. '{print $NF}')
+        PKGVER="$TODAY.$((N + 1))"
+    else
+        PKGVER="$TODAY.1"
+    fi
+    echo "Version: $PKGVER"
+    TMPDIR=$(mktemp -d)
+    ORIG_VER=$(grep '^version = ' "$REPO_ROOT/pyproject.toml" | head -1 | cut -d'"' -f2)
+    trap 'sed -i "s/^version = .*/version = \"$ORIG_VER\"/" "$REPO_ROOT/pyproject.toml"; rm -rf "$TMPDIR"' EXIT
+    sed -i "s/^version = .*/version = \"$PKGVER\"/" "$REPO_ROOT/pyproject.toml"
+    (cd "$REPO_ROOT" && uv build --wheel)
+    WHEEL_NAME="voxy_linux-${PKGVER}-py3-none-any.whl"
+    WHEEL_ABS="$REPO_ROOT/dist/$WHEEL_NAME"
+    SHA256=$(sha256sum "$WHEEL_ABS" | awk '{print $1}')
+    cp "$REPO_ROOT/PKGBUILD" "$TMPDIR/PKGBUILD"
+    cp "$WHEEL_ABS" "$TMPDIR/$WHEEL_NAME"
+    sed -i \
+        -e "s|pkgver=.*|pkgver=$PKGVER|" \
+        -e "s|sha256sums=(.*)|sha256sums=(\"$SHA256\")|" \
+        "$TMPDIR/PKGBUILD"
+    cd "$TMPDIR" && makepkg -f --nodeps --noconfirm 2>&1
+    cp "$TMPDIR"/*.pkg.tar.zst "$REPO_ROOT/dist/"
+    echo "Arch package: dist/$(ls $TMPDIR/*.pkg.tar.zst | xargs basename)"
+
 # Remove build artifacts
 clean:
-    rm -rf dist/ .venv/
+    rm -rf dist/ build/
+
+# Wipe everything including venv
+purge: clean
+    rm -rf .venv/

--- a/presetup-arch.sh
+++ b/presetup-arch.sh
@@ -15,7 +15,7 @@ fi
 # wayland text insertion
 if [[ -n "${WAYLAND_DISPLAY:-}" ]] || [[ "${XDG_SESSION_TYPE:-}" == "wayland" ]]; then
     pacman -Qi wl-clipboard &>/dev/null || PKGS+=(wl-clipboard)
-    pacman -Qi ydotool      &>/dev/null || PKGS+=(ydotool)
+    pacman -Qi ydotool &>/dev/null || PKGS+=(ydotool)
 fi
 
 # wayland cursor overlay (optional, opt-in via [ui] cursor_overlay)
@@ -26,8 +26,8 @@ if [[ -n "${WAYLAND_DISPLAY:-}" ]] || [[ "${XDG_SESSION_TYPE:-}" == "wayland" ]]
     pacman -Qi python-cairo       &>/dev/null || PKGS+=(python-cairo)
 fi
 
-# x11 text insertion
-if [[ -n "${DISPLAY:-}" ]] || [[ "${XDG_SESSION_TYPE:-}" == "x11" ]]; then
+# x11 text insertion (pure X11, or KDE Plasma Wayland which uses XWayland)
+if [[ -n "${DISPLAY:-}" ]] || [[ "${XDG_SESSION_TYPE:-}" == "x11" ]] || [[ "${XDG_CURRENT_DESKTOP:-}" == "KDE" ]]; then
     pacman -Qi xclip   &>/dev/null || PKGS+=(xclip)
     pacman -Qi xdotool &>/dev/null || PKGS+=(xdotool)
 fi
@@ -39,7 +39,7 @@ else
     echo "All system packages already installed."
 fi
 
-# --- ydotoold daemon (Wayland only) ---
+# --- ydotoold daemon ---
 
 if pacman -Qi ydotool &>/dev/null; then
     if ! systemctl --user is-enabled --quiet ydotool 2>/dev/null; then
@@ -60,18 +60,6 @@ if [[ -f "$CUBLAS_LIB/libcublas.so.13" ]] && [[ ! -e "$CUBLAS_LIB/libcublas.so.1
     sudo ldconfig
 else
     [[ -e "$CUBLAS_LIB/libcublas.so.12" ]] && echo "libcublas.so.12 already present."
-fi
-
-# --- input group (needed for evdev hotkey capture) ---
-
-if getent group input &>/dev/null; then
-    if ! id -nG "$USER" | grep -qw input; then
-        echo "Adding $USER to input group..."
-        sudo usermod -aG input "$USER"
-        echo "WARNING: Log out and back in for group membership to take effect."
-    else
-        echo "$USER already in input group."
-    fi
 fi
 
 echo ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "voxy-linux"
-version = "0.1.0"
+version = "2026.5.4.1"
 description = "Local offline voice dictation for Linux"
 readme = "README.md"
-license = { file = "LICENSE" }
+license = "MIT"
+license-files = ["LICENSE"]
 requires-python = ">=3.11"
 classifiers = [
-    "License :: OSI Approved :: MIT License",
     "Operating System :: POSIX :: Linux",
 ]
 dependencies = [

--- a/src/voxy/app.py
+++ b/src/voxy/app.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 
 from .audio import AudioRecorder, AudioFeedback
 from .cursor_overlay import CursorOverlay, _NullCursorOverlay
-from .hotkey import HotkeyListener, check_input_group
+from .hotkey import HotkeyListener
 from .inserter import TextInserter, check_tools
 from .overlay import OverlayUI
 from .postprocess import PostProcessor
@@ -108,7 +108,6 @@ class App:
 
     def run(self) -> None:
         """Block until Ctrl-C, firing record/transcribe/insert on each press."""
-        check_input_group()
         check_tools(self._inserter._method)
         listener = HotkeyListener(
             key=self._key,

--- a/src/voxy/hotkey.py
+++ b/src/voxy/hotkey.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import grp
 import io
 import logging
 import os
@@ -99,7 +98,8 @@ class HotkeyListener:
     """Fires on_press / on_release callbacks for a configured hotkey.
 
     Uses evdev (reads from /dev/input) as primary backend; falls back to
-    pynput if evdev access fails (e.g. missing `input` group membership).
+    pynput if evdev finds no accessible keyboard devices (e.g. missing
+    ``input`` group membership on systems where that applies).
     """
 
     _key: str
@@ -248,20 +248,3 @@ class HotkeyListener:
             self._stop_event.wait()
             listener.stop()
 
-
-# ---------------------------------------------------------------------------
-# Startup check
-# ---------------------------------------------------------------------------
-
-def check_input_group() -> None:
-    """Raise RuntimeError with actionable message if not in `input` group."""
-    try:
-        input_gid = grp.getgrnam("input").gr_gid
-    except KeyError:
-        return  # no input group on this system
-    if input_gid not in os.getgroups():
-        raise RuntimeError(
-            "voxy requires membership in the 'input' group to capture hotkeys via evdev.\n"
-            "  Fix: sudo usermod -aG input $USER  (then log out and back in)\n"
-            "  Or run voxy as root (not recommended)."
-        )

--- a/src/voxy/inserter.py
+++ b/src/voxy/inserter.py
@@ -12,9 +12,31 @@ _DETECT_TIMEOUT: float = 0.5  # seconds — detection must not block the insert 
 _TERMINAL_CLASSES: frozenset[str] = frozenset({
     "konsole", "org.kde.konsole",
     "gnome-terminal", "gnome-terminal-server", "org.gnome.terminal",
+    "kgx", "org.gnome.console",
+    "org.gnome.ptyxis",
+    "com.raggesilver.blackbox",
     "alacritty",
     "ghostty", "com.mitchellh.ghostty",
     "kitty",
+    "terminator",
+    "xterm", "uxterm",
+    "tilix",
+    "foot",
+    "wezterm",
+    "warp",
+    "urxvt",
+    "xfce4-terminal",
+    "qterminal",
+    "lxterminal",
+    "mate-terminal",
+    "yakuake", "org.kde.yakuake",
+    "guake",
+    "tilda",
+    "hyper",
+    "tabby",
+    "contour",
+    "terminology",
+    "deepin-terminal",
 })
 
 # ydotool keycodes: 29=Ctrl, 42=Shift, 47=V
@@ -22,11 +44,19 @@ _YDOTOOL_CTRL_V: list[str] = ["29:1", "47:1", "47:0", "29:0"]
 _YDOTOOL_CTRL_SHIFT_V: list[str] = ["29:1", "42:1", "47:1", "47:0", "42:0", "29:0"]
 
 
+def _is_kde_wayland() -> bool:
+    return (
+        os.environ.get("XDG_CURRENT_DESKTOP", "").lower() == "kde"
+        and bool(os.environ.get("WAYLAND_DISPLAY"))
+        and bool(os.environ.get("DISPLAY"))
+    )
+
+
 def check_tools(method: str = "auto") -> None:
     """Raise RuntimeError with install instructions if required tools are missing."""
     if method == "auto":
         if os.environ.get("WAYLAND_DISPLAY"):
-            method = "wayland"
+            method = "x11" if _is_kde_wayland() else "wayland"
         elif os.environ.get("DISPLAY"):
             method = "x11"
         else:
@@ -64,7 +94,7 @@ class TextInserter:
         if self._method != "auto":
             return self._method
         if os.environ.get("WAYLAND_DISPLAY"):
-            return "wayland"
+            return "x11" if _is_kde_wayland() else "wayland"
         if os.environ.get("DISPLAY"):
             return "x11"
         raise RuntimeError(
@@ -78,6 +108,8 @@ class TextInserter:
             return self._focused_class_hyprland()
         if os.environ.get("SWAYSOCK"):
             return self._focused_class_sway()
+        if _is_kde_wayland():
+            return self._focused_class_kde_wayland()
         # GNOME native Wayland without XWayland: try gdbus before xdotool
         if (
             os.environ.get("XDG_CURRENT_DESKTOP", "").lower() == "gnome"
@@ -149,6 +181,36 @@ class TextInserter:
                 app_id = app_id.get("class", "")
             return str(app_id).lower() if app_id else ""
         except (subprocess.TimeoutExpired, OSError, json.JSONDecodeError, KeyError, AttributeError):
+            return ""
+
+    def _focused_class_kde_wayland(self) -> str:
+        # XWayland path: fastest and most reliable on typical KDE Plasma installs.
+        if os.environ.get("DISPLAY"):
+            cls = self._focused_class_x11()
+            if cls:
+                return cls
+        # Pure Wayland fallback: qdbus gives X11 window ID, xprop reads WM_CLASS.
+        try:
+            win = subprocess.run(
+                ["qdbus", "org.kde.KWin", "/KWin", "activeWindow"],
+                capture_output=True, text=True, check=False,
+                timeout=_DETECT_TIMEOUT,
+            )
+            if win.returncode != 0 or not win.stdout.strip():
+                return ""
+            # qdbus may return bare int or "uint 12345" depending on version
+            win_id = win.stdout.strip().split()[-1]
+            if not win_id.isdigit():
+                return ""
+            xprop = subprocess.run(
+                ["xprop", "-id", win_id, "WM_CLASS"],
+                capture_output=True, text=True, check=False,
+                timeout=_DETECT_TIMEOUT,
+            )
+            if xprop.returncode != 0:
+                return ""
+            return xprop.stdout.lower()
+        except (subprocess.TimeoutExpired, OSError):
             return ""
 
     def _focused_class_gnome_wayland(self) -> str:


### PR DESCRIPTION
Closes #47.

## Summary

- Remove the `check_input_group()` startup guard — `HotkeyListener` already falls back from evdev to pynput when keyboard devices are inaccessible, so the up-front check just blocks legitimate non-Hyprland users.
- Add KDE Plasma Wayland focused-window detection (`_focused_class_kde_wayland`) using `xdotool` via XWayland with a `qdbus` + `xprop` pure-Wayland fallback so terminals get `Ctrl+Shift+V` instead of `Ctrl+V`.
- Route KDE Plasma Wayland through the `x11` backend (xclip + xdotool via XWayland). Avoids the `ydotool` daemon + `input` group setup that the `wayland` branch requires. `wtype` was tried but KDE does not expose `zwp_virtual_keyboard_v1` to regular clients (`Compositor does not support the virtual keyboard protocol`).
- Expand `_TERMINAL_CLASSES` from ~6 to ~25 (Terminator, urxvt, xfce4-terminal, qterminal, lxterminal, mate-terminal, yakuake, guake, tilda, hyper, tabby, contour, terminology, deepin-terminal, kgx/GNOME Console, Ptyxis, Black Box, foot, wezterm, warp, xterm, tilix).
- PKGBUILD: switch venv install to `uv pip install` (cache-aware, much faster Arch builds). Keep `python -m venv` so the shebang anchors to system Python.
- `presetup-arch.sh`: drop the `input group` block and add KDE Plasma → `xclip` + `xdotool` routing.
- README: rewrite the prereq table desktop-aware (KDE Plasma, Wayland-other, X11) instead of bare display-server.

## Test plan

- [ ] On KDE Plasma 6 Wayland: install with `presetup-arch.sh` + PKGBUILD, run `voxy`, hold hotkey, speak — text inserts correctly into a non-terminal app (Ctrl+V).
- [ ] In Konsole / Terminator / Yakuake on KDE Plasma Wayland: text inserts via Ctrl+Shift+V (no literal `v` printed).
- [x] User is NOT in the `input` group: voxy still starts (pynput fallback for hotkeys, xdotool for paste).
- [x] On Hyprland: existing evdev + ydotool path still works (no regression).
- [ ] On X11 (any DE): xclip + xdotool path unchanged.
- [ ] `just build-arch` completes meaningfully faster than before on a warm uv cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)